### PR TITLE
fix(get-versions): SemVer として解釈できないバージョンを除外する

### DIFF
--- a/tools/get-versions.py
+++ b/tools/get-versions.py
@@ -77,6 +77,9 @@ def is_supported_version(version):
         return False
 
     ajusted_version = get_semver_ajusted_version(version)
+    # 26.1.1.build.8 のように SemVer として解釈できないバージョンはサポートしない
+    if not semver.Version.is_valid(ajusted_version):
+        return False
     # 1.20.5-R0.1-SNAPSHOT は net.kyori:adventure-bom が 4.17.0-SNAPSHOT を指しておりビルドできないため除外
     if semver.match(ajusted_version, "1.20.5"):
         return False


### PR DESCRIPTION
## 概要

`tools/get-versions.py` の `Get versions` ジョブが、PaperMC の maven-metadata.xml に含まれる `26.1.1.build.8` のような SemVer として解釈できないバージョン文字列に対して `semver.match()` を呼び出し、`ValueError` で落ちていました。

```
ValueError: 26.1.1.build.8 is not valid SemVer string
```

## 対応内容

- `is_supported_version()` の先頭で `semver.Version.is_valid()` による事前検証を追加し、SemVer として解釈できないバージョンは非サポートとしてスキップするよう修正

## 動作確認

- ローカルで `python3 tools/get-versions.py` を実行し、例外なく正常終了することを確認
- 出力 JSON に `26.1.1.build.8` を含む非サポートバージョンが含まれないことを確認
- 既存の対応バージョン (1.16.5〜) は引き続き出力されることを確認

## 関連

Renovate PR #125 の `Get versions` チェック失敗（本 PR のバンプとは無関係の既存バグ）の修正です。同じ `Get versions` の失敗は他の複数の Renovate PR でも共通して発生しています。